### PR TITLE
feat: add nodes and edges to topoContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ const graph = topo({
 })
 
 {
-  queue: ['plk-a', 'pkg-b', 'pkg-x', 'pkg-y', 'pkg-x']
+  queue: ['pkg-a', 'pkg-b', 'pkg-z', 'pkg-y', 'pkg-x'],
+  nodes: ['pkg-a', 'pkg-b', 'pkg-x', 'pkg-y', 'pkg-z'],
+  edges: [
+    ['pkg-a', 'pkg-b'],
+    ['pkg-z', 'pkg-y'],
+    ['pkg-y', 'pkg-x'],
+  ]
 }
 ```
 

--- a/src/main/ts/index.ts
+++ b/src/main/ts/index.ts
@@ -18,12 +18,22 @@ export interface IPackageJson {
   peerDependencies?: Record<string, string>
 }
 
-export const topo = async (otions: ITopoOtions): Promise<{ queue: string[] }> => {
+export interface ITopoContext {
+  queue: string[]
+  nodes: string[]
+  edges: [string, string | undefined][]
+}
+
+export const topo = async (otions: ITopoOtions): Promise<ITopoContext> => {
   const manifestsPaths = await getManifestsPaths(otions)
   const manifests = await Promise.all(manifestsPaths.map(p => readFile(p, 'utf-8').then(JSON.parse)))
   const { edges, nodes } = getGraph(manifests)
 
-  return { queue: toposort.array(nodes, edges) }
+  return {
+    queue: toposort.array(nodes, edges),
+    edges,
+    nodes,
+  }
 }
 
 export const getGraph = (manifests: IPackageJson[]): {

--- a/src/test/ts/index.ts
+++ b/src/test/ts/index.ts
@@ -20,8 +20,14 @@ test('`getManifestsPaths` returns absolute package.json refs', async () => {
 test('`topo` returns monorepo release queue', async () => {
   const cwd = resolve(fixtures, 'regular-monorepo')
   const workspaces = ['packages/*']
-  const result = (await topo({cwd, workspaces})).queue
-  const expected = ['a', 'e', 'c']
+  const result = await topo({cwd, workspaces})
+  const expected = {
+    queue: ['a', 'e', 'c'],
+    nodes: ['a', 'c', 'e'],
+    edges: [
+      [ 'e', 'c' ]
+    ],
+  }
 
   assert.equal(result, expected)
 })


### PR DESCRIPTION
## Changes
Add `nodes` and `edges` to topo result:
```js
const graph = topo({
  workspaces: ['packages/*']
})

// result
{
  queue: ['pkg-a', 'pkg-b', 'pkg-z', 'pkg-y', 'pkg-x'],
  nodes: ['pkg-a', 'pkg-b', 'pkg-x', 'pkg-y', 'pkg-z'],
  edges: [
    ['pkg-a', 'pkg-b'],
    ['pkg-z', 'pkg-y'],
    ['pkg-y', 'pkg-x'],
  ]
}
```

- [x] New code is covered by tests
- [x] All the changes are mentioned in docs (readme.md)
