### PR TITLE
feat: add pkg manifests to topoContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ yarn add @semrel-extra/topo
 import { topo } from '@semrel-extra/topo'
 
 const graph = topo({
-  workspaces: ['packages/*']
+  workspaces: ['packages/*'],
+  cwd: '/path/to/project/root'
 })
 
 {
@@ -26,7 +27,19 @@ const graph = topo({
     ['pkg-a', 'pkg-b'],
     ['pkg-z', 'pkg-y'],
     ['pkg-y', 'pkg-x'],
-  ]
+  ],
+  packages: {
+    'pkg-a': {
+      manifest: {
+        name: 'pkg-a',
+        dependencies: {}
+      },
+      manifestPath: '/absolute/path/to/packages/a/package.json',
+      path: 'packages/pkg-a'
+    },
+    'pkg-b': {...},
+    ...
+  }
 }
 ```
 

--- a/src/test/ts/index.ts
+++ b/src/test/ts/index.ts
@@ -27,6 +27,32 @@ test('`topo` returns monorepo release queue', async () => {
     edges: [
       [ 'e', 'c' ]
     ],
+    packages: {
+      a: {
+        manifest: {
+          name: 'a'
+        },
+        manifestPath: join(cwd, 'packages/a/package.json'),
+        path: 'packages/a'
+      },
+      c: {
+        manifest: {
+          name: 'c',
+          dependencies: {
+            e: '*'
+          },
+        },
+        manifestPath: join(cwd, 'packages/c/package.json'),
+        path: 'packages/c'
+      },
+      e: {
+        manifest: {
+          name: 'e'
+        },
+        manifestPath: join(cwd, 'packages/e/package.json'),
+        path: 'packages/e'
+      }
+    }
   }
 
   assert.equal(result, expected)

--- a/src/test/ts/index.ts
+++ b/src/test/ts/index.ts
@@ -17,7 +17,7 @@ test('`getManifestsPaths` returns absolute package.json refs', async () => {
   assert.equal(result, expected)
 })
 
-test('`topo` returns monorepo release queue', async () => {
+test('`topo` returns monorepo digest: release queue, deps graph, package manifests', async () => {
   const cwd = resolve(fixtures, 'regular-monorepo')
   const workspaces = ['packages/*']
   const result = await topo({cwd, workspaces})


### PR DESCRIPTION
## Changes
Add manifests map to topoContext:
```js
import { topo } from '@semrel-extra/topo'

const graph = topo({
  workspaces: ['packages/*'],
  cwd: '/path/to/project/root'
})

{
  queue: ['pkg-a', 'pkg-b', 'pkg-z', 'pkg-y', 'pkg-x'],
  nodes: ['pkg-a', 'pkg-b', 'pkg-x', 'pkg-y', 'pkg-z'],
  edges: [
    ['pkg-a', 'pkg-b'],
    ['pkg-z', 'pkg-y'],
    ['pkg-y', 'pkg-x'],
  ],
  packages: {
    'pkg-a': {
      manifest: {
        name: 'pkg-a',
        dependencies: {}
      },
      manifestPath: '/absolute/path/to/packages/a/package.json',
      path: 'packages/pkg-a'
    },
    'pkg-b': {...},
    ...
  }
}
```

- [x] New code is covered by tests
- [x] All the changes are mentioned in docs (readme.md)
